### PR TITLE
Add CI and fix errors

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -15,25 +15,21 @@ jobs:
         env:
           - ROS_DISTRO: rolling
             ROS_REPO: main
-            CCOV: true
     env:
       BEFORE_SETUP_UPSTREAM_WORKSPACE: 'sudo apt-get -qq install -y --no-upgrade --no-install-recommends git && git config --global --add safe.directory "*"'
-      AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
       TARGET_CMAKE_ARGS: >
-        -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'Debug' || 'Release'}}
-        ${{ matrix.env.CCOV && '-DCMAKE_CXX_FLAGS="--coverage" --no-warn-unused-cli' || '' }}
+        -DCMAKE_BUILD_TYPE='Release'
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BASEDIR: ${{ github.workspace }}/.work
-      CACHE_PREFIX: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.CCOV && '-ccov' || '' }}
+      CACHE_PREFIX: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
 
-    name: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.CCOV && ' + ccov' || ''}}"
+    name: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
-        if: ${{ ! matrix.env.CCOV }}
         uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ env.BASEDIR }}/target_ws
@@ -51,19 +47,8 @@ jobs:
       - name: industrial_ci
         uses: "ros-industrial/industrial_ci@master"
         env: ${{ matrix.env }}
-      - name: upload test artifacts (on failure)
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: test-results
-          path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml
-      - name: upload codecov report
-        uses: codecov/codecov-action@v1
-        if: ${{ matrix.env.CCOV }}
-        with:
-          files: ${{ env.BASEDIR }}/coverage.info
       - name: prepare target_ws for cache
-        if: ${{ always() && ! matrix.env.CCOV }}
+        if: ${{ always()}}
         run: |
           du -sh ${{ env.BASEDIR }}/target_ws
           sudo find ${{ env.BASEDIR }}/target_ws -wholename '*/test_results/*' -delete

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,71 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: Build and Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - ROS_DISTRO: rolling
+            ROS_REPO: main
+            CCOV: true
+    env:
+      BEFORE_SETUP_UPSTREAM_WORKSPACE: 'sudo apt-get -qq install -y --no-upgrade --no-install-recommends git && git config --global --add safe.directory "*"'
+      AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
+      TARGET_CMAKE_ARGS: >
+        -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'Debug' || 'Release'}}
+        ${{ matrix.env.CCOV && '-DCMAKE_CXX_FLAGS="--coverage" --no-warn-unused-cli' || '' }}
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      BASEDIR: ${{ github.workspace }}/.work
+      CACHE_PREFIX: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.CCOV && '-ccov' || '' }}
+
+    name: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.CCOV && ' + ccov' || ''}}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # The target directory cache doesn't include the source directory because
+      # that comes from the checkout.  See "prepare target_ws for cache" task below
+      - name: cache target_ws
+        if: ${{ ! matrix.env.CCOV }}
+        uses: pat-s/always-upload-cache@v2.1.5
+        with:
+          path: ${{ env.BASEDIR }}/target_ws
+          key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
+      - name: cache ccache
+        uses: pat-s/always-upload-cache@v2.1.5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
+            ccache-${{ env.CACHE_PREFIX }}
+      - name: industrial_ci
+        uses: "ros-industrial/industrial_ci@master"
+        env: ${{ matrix.env }}
+      - name: upload test artifacts (on failure)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-results
+          path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml
+      - name: upload codecov report
+        uses: codecov/codecov-action@v1
+        if: ${{ matrix.env.CCOV }}
+        with:
+          files: ${{ env.BASEDIR }}/coverage.info
+      - name: prepare target_ws for cache
+        if: ${{ always() && ! matrix.env.CCOV }}
+        run: |
+          du -sh ${{ env.BASEDIR }}/target_ws
+          sudo find ${{ env.BASEDIR }}/target_ws -wholename '*/test_results/*' -delete
+          sudo rm -rf ${{ env.BASEDIR }}/target_ws/src
+          du -sh ${{ env.BASEDIR }}/target_ws

--- a/abb_rapid_sm_addin_msgs/CMakeLists.txt
+++ b/abb_rapid_sm_addin_msgs/CMakeLists.txt
@@ -25,11 +25,11 @@ endif()
 ########################################################################################################################
 project(${extracted_name} VERSION ${extracted_version})
 
-if (NOT CMAKE_CXX_STANDARD)
+if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-if (CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 

--- a/abb_rapid_sm_addin_msgs/package.xml
+++ b/abb_rapid_sm_addin_msgs/package.xml
@@ -16,7 +16,8 @@
   <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
-
+  <test_depend>ament_lint_common</test_depend>
+  
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/abb_robot_msgs/CMakeLists.txt
+++ b/abb_robot_msgs/CMakeLists.txt
@@ -25,11 +25,11 @@ endif()
 ########################################################################################################################
 project(${extracted_name} VERSION ${extracted_version})
 
-if (NOT CMAKE_CXX_STANDARD)
+if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-if (CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 

--- a/abb_robot_msgs/CMakeLists.txt
+++ b/abb_robot_msgs/CMakeLists.txt
@@ -73,6 +73,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES std_msgs
   ADD_LINTER_TESTS
 )
+ament_export_dependencies(rosidl_default_runtime)
 
-ament_export_dependencies(rosidl_default_generators)
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/abb_robot_msgs/package.xml
+++ b/abb_robot_msgs/package.xml
@@ -15,6 +15,10 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_cmake</test_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
Currently, this repo has a dependency issue that is is causing abb_ros2 CI to fail with this error:
```
  CMake Error at /opt/ros/rolling/share/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake:177 (find_package):
    By not providing "Findament_cmake_cppcheck.cmake" in CMAKE_MODULE_PATH this
    project has asked CMake to find a package configuration file provided by
    "ament_cmake_cppcheck", but CMake did not find one.
  
    Could not find a package configuration file provided by
    "ament_cmake_cppcheck" with any of the following names:
  
      ament_cmake_cppcheckConfig.cmake
      ament_cmake_cppcheck-config.cmake
  
    Add the installation prefix of "ament_cmake_cppcheck" to CMAKE_PREFIX_PATH
    or set "ament_cmake_cppcheck_DIR" to a directory containing one of the
    above files.  If "ament_cmake_cppcheck" provides a separate development
    package or SDK, be sure it has been installed.
  Call Stack (most recent call first):
    /opt/ros/rolling/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
    /opt/ros/rolling/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
    CMakeLists.txt:70 (rosidl_generate_interfaces)
```

This PR adds the same CI used in abb_ros2 as well as fixes the dependencies and formatting issues that cause the CI failure.